### PR TITLE
fix: remove hatch-regex dependency and update CI pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,25 @@ jobs:
         run: |
           PYTHONPATH=src python3 tests/test_version.py
 
+  # ── Python Build Verification ─────────────────────────────────
+  build-check:
+    name: "Python Package Build Check"
+    needs: changes
+    if: |
+      needs.changes.outputs.any == 'true' ||
+      github.event.inputs.run_all == 'true' ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install build tool
+        run: python3 -m pip install build
+      - name: Build sdist and wheel
+        run: python3 -m build
+
   # ── Base image — runs per distro ────────────────────────────
   # Re-runs when generate.js changes or on workflow_dispatch.
   # Humble and Jazzy are tested independently because their
@@ -293,6 +312,7 @@ jobs:
     needs:
       - changes
       - version-check
+      - build-check
       - base-humble
       - base-humble-desktop
       - base-jazzy
@@ -310,6 +330,7 @@ jobs:
         run: |
           results[changes]="${{ needs.changes.result }}"
           results[version-check]="${{ needs.version-check.result }}"
+          results[build-check]="${{ needs.build-check.result }}"
           results[base-humble]="${{ needs.base-humble.result }}"
           results[base-humble-desktop]="${{ needs.base-humble-desktop.result }}"
           results[base-jazzy]="${{ needs.base-jazzy.result }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a comprehensive version consistency test suite (`tests/test_version.py`).
 - Added `tests/sync_version.py` for automated version management.
 - Added GitHub Actions for automated publishing to GitHub Releases.
+- Automated publication to PyPI and GitHub Releases via `softprops/action-gh-release@v2`.
+- `build-check` verification step in PR pipelines (`ci.yml`) to guarantee PyPI package build success.
+- Local Git `pre-push` hook installation script (`scripts/install_hooks.sh`) for fast local CI checks.
 
 ### Changed
 - Refactored `index.html` and CLI to dynamically consume version from `config.json`.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 <p align="center">
   <a href="https://github.com/ppswaroopa/ros2-dockergen/actions/workflows/ci.yml"><img src="https://github.com/ppswaroopa/ros2-dockergen/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/ppswaroopa/ros2-dockergen/actions/workflows/publish.yml"><img src="https://github.com/ppswaroopa/ros2-dockergen/actions/workflows/publish.yml/badge.svg" alt="Publish to PyPI"></a>
   <a href="https://pypi.org/project/ros2-dockergen/"><img src="https://img.shields.io/pypi/v/ros2-dockergen.svg" alt="PyPI version"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10+-blue.svg" alt="Python 3.10+"></a>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling", "hatch-regex"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]

--- a/scripts/install_hooks.sh
+++ b/scripts/install_hooks.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# =============================================================
+# install_hooks.sh
+# Installs local git hooks for the ros2-dockergen repository
+# to catch simple errors before pushing to the remote.
+# =============================================================
+
+set -e
+
+HOOKS_DIR=".git/hooks"
+PRE_PUSH_HOOK="${HOOKS_DIR}/pre-push"
+
+if [ ! -d ".git" ]; then
+  echo "Error: This script must be run from the root of the repository."
+  exit 1
+fi
+
+echo "Installing pre-push hook..."
+
+cat > "$PRE_PUSH_HOOK" << 'EOF'
+#!/usr/bin/env bash
+# =============================================================
+# pre-push git hook
+# Runs a quick Python build check to catch PyPI packaging
+# errors locally before they break the CI pipeline.
+# =============================================================
+
+echo ""
+echo "==== Running pre-push checks ===="
+
+# Use a temporary virtual environment to avoid PEP-668 "externally-managed-environment" errors
+VENV_DIR="/tmp/ros2-dockergen-pre-push-venv"
+
+if [ ! -d "$VENV_DIR" ]; then
+  echo "Creating isolated build environment..."
+  python3 -m venv "$VENV_DIR" > /dev/null
+  "$VENV_DIR/bin/pip" install build > /dev/null
+fi
+
+echo "Verifying Python package build..."
+if ! "$VENV_DIR/bin/python" -m build > /dev/null; then
+    echo "❌ ERROR: 'python3 -m build' failed!"
+    echo "This means the package will fail to publish on PyPI."
+    echo "Please run 'python3 -m build' locally to see the error details."
+    echo "Push aborted."
+    echo "================================="
+    exit 1
+fi
+
+echo "✓ Build check passed."
+echo "================================="
+echo ""
+exit 0
+EOF
+
+chmod +x "$PRE_PUSH_HOOK"
+
+echo "✓ Successfully installed .git/hooks/pre-push!"
+echo "Now, every time you run 'git push', it will verify the Python package builds securely."


### PR DESCRIPTION
This PR resolves PyPI build failure and implements layers of additional protection to catch packaging regressions early.

Here are the complete details for your Pull Request to completely cover everything we just accomplished!

### What changed
1. **PyPI Build Fix**: Removed the pseudo-dependency `hatch-regex` from `pyproject.toml`'s `build-system.requires` list. Hatchling natively supports regex-based version extraction, so this missing PyPI package was unnecessarily failing the build.
2. **Preventative PR Check**: Added a new `build-check` verification job to `.github/workflows/ci.yml`. GitHub Actions will now explicitly run `python3 -m build` for every PR, ensuring no bad dependencies can break `main`.
3. **Local Fast Checks**: Added a developer quality-of-life script at `scripts/install_hooks.sh`. Generating a local `pre-push` Git hook, this spins up an isolated `/tmp` virtual environment (to bypass strict Linux PEP-668 restrictions) and verifies the package builds correctly *before* allowing the push to reach the remote.
4. **Documentation**: Updated `CHANGELOG.md` with these new CI safety nets, and added the *Publish to PyPI* workflow status badge to the `README.md`. 

### Validation
- Local tests using `python3 -m build` successfully generate the `.tar.gz` and `.whl` files.
- Verified the local `pre-push` hook builds dynamically inside a temporary isolated virtual environment and correctly blocks pushes on build failure.
- Badges check and changelog formatting reviewed and passing visually.